### PR TITLE
obsFunction to inflate errors for conventional observations-Temperature, moisture and wind based on vertical density to match GSI results

### DIFF
--- a/testinput_tier_1/converr_vadwind_geoval_2020120112_s.nc4
+++ b/testinput_tier_1/converr_vadwind_geoval_2020120112_s.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9a16d1583b885f1780682c2846dcf69969da635e19dd024c04719af8b453a1d
+size 140880

--- a/testinput_tier_1/converr_vadwind_obs_2020120112_s.nc4
+++ b/testinput_tier_1/converr_vadwind_obs_2020120112_s.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56d82f419389f47af8447648177044f806c78d2c823011dfec398440060c1ad2
+size 34318


### PR DESCRIPTION
## Description

Upload test data, geovals and obs,  for PR [JCSDA-internal/ufo#710](https://github.com/JCSDA-internal/ufo/pull/710), testing the obsFunction to inflate errors for convenational observations. 

### Issue(s) addressed

Link the issues to be closed with this PR
[JCSDA-internal/ufo#480](https://github.com/JCSDA-internal/ufo/issues/480)

## Dependencies

- [ ] [JCSDA-internal/ufo#710](https://github.com/JCSDA-internal/ufo/pull/710)
